### PR TITLE
How to enable bitmap fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ Check emojis here!
 🥶 😳 🤪 😵 😡 😠 🤬 😷 🤒 🤕 🤢 🤮 🤧 😇 🤠 🤡 🥳 🥴 🥺 🤥 🤫 🤭 🧐 🤓 😈 👿 👹 👺 💀 👻 👽 🤖 💩 
 😺 😸 😹 😻 😼 😽 🙀 😿 😾
 ```
+
+## Troubleshooting
+
+Bitmap fonts may be disabled. To enable try to remove symlink `/etc/fonts/conf.d/70-no-bitmaps.conf`


### PR DESCRIPTION
Didn't work on localhost. My arch required an extra step.

Solution found there: https://bbs.archlinux.org/viewtopic.php?pid=2141395#p2141395

> I had the same issue and deleting the `/etc/fonts/conf.d/70-no-bitmaps.conf` symlink fixed it for me. I guess fontconfig 2.15 considers Noto Color Emoji a bitmap font.